### PR TITLE
Fixed capitalization of sirupsen

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -6,7 +6,7 @@ package evloghook
 import (
 	"golang.org/x/sys/windows/svc/eventlog"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const levels = eventlog.Error | eventlog.Warning | eventlog.Info


### PR DESCRIPTION
The repo that used to be Sirupsen/logrus is now sirupsen/logrus; trying to use this hook without correcting the capitalization fails.